### PR TITLE
README: change logo image to a white-bordered one

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-    <img alt="Logo" src="https://github.com/perl-ide/general/assets/453611/fabf497a-c7b9-488f-910e-5c6d1ce912a6" height="240" />
+    <img alt="Logo" src="https://github.com/perl-ide/.github/assets/453611/4ed8dd78-3c87-4b95-b808-639ca07777de" height="240" />
 </p>
 
 # Perl Development Environments (a.k.a. Perl IDE)


### PR DESCRIPTION
To avoid bad visibility on dark scheme browser, change the logo image to a new one with a white border around the black camel.

This PR fixes #3.